### PR TITLE
refactor: centralize optional controller init (prepare pointer extraction)

### DIFF
--- a/resources/ext.layers.editor/CanvasManager.js
+++ b/resources/ext.layers.editor/CanvasManager.js
@@ -1643,40 +1643,7 @@ class CanvasManager {
 		if ( this.pointerController && typeof this.pointerController.getMousePointFromClient === 'function' ) {
 			return this.pointerController.getMousePointFromClient( clientX, clientY );
 		}
-
-		// If PointerController class is available but wasn't initialized, try a temp instance.
-		const PClass = findClass( 'PointerController' );
-		if ( PClass ) {
-			try {
-				const tmp = new PClass( this );
-				if ( tmp && typeof tmp.getMousePointFromClient === 'function' ) {
-					const val = tmp.getMousePointFromClient( clientX, clientY );
-					tmp.destroy && tmp.destroy();
-					return val;
-				}
-			} catch ( e ) {
-				if ( typeof mw !== 'undefined' && mw.log && mw.log.warn ) {
-					mw.log.warn( '[CanvasManager] Temporary PointerController call failed:', e && e.message );
-				}
-			}
-		}
-
-		// Fallback: inline conversion (kept for environments without PointerController)
-		const rect = this.canvas.getBoundingClientRect();
-		const relX = clientX - rect.left;
-		const relY = clientY - rect.top;
-		const scaleX = this.canvas.width / rect.width;
-		const scaleY = this.canvas.height / rect.height;
-		let canvasX = relX * scaleX;
-		let canvasY = relY * scaleY;
-
-		if ( this.snapToGrid && this.gridSize > 0 ) {
-			const gridSize = this.gridSize;
-			canvasX = Math.round( canvasX / gridSize ) * gridSize;
-			canvasY = Math.round( canvasY / gridSize ) * gridSize;
-		}
-
-		return { x: canvasX, y: canvasY };
+		throw new Error( 'PointerController not initialized: getMousePointFromClient requires PointerController' );
 	}
 
 	// Raw mapping without snapping, useful for ruler hit testing
@@ -1684,31 +1651,7 @@ class CanvasManager {
 		if ( this.pointerController && typeof this.pointerController.getRawClientPoint === 'function' ) {
 			return this.pointerController.getRawClientPoint( e );
 		}
-
-		// Try temporary PointerController instance if available
-		const PClass = findClass( 'PointerController' );
-		if ( PClass ) {
-			try {
-				const tmp = new PClass( this );
-				if ( tmp && typeof tmp.getRawClientPoint === 'function' ) {
-					const val = tmp.getRawClientPoint( e );
-					tmp.destroy && tmp.destroy();
-					return val;
-				}
-			} catch ( err ) {
-				if ( typeof mw !== 'undefined' && mw.log && mw.log.warn ) {
-					mw.log.warn( '[CanvasManager] Temporary PointerController raw call failed:', err && err.message );
-				}
-			}
-		}
-
-		const rect = this.canvas.getBoundingClientRect();
-		const clientX = e.clientX - rect.left;
-		const clientY = e.clientY - rect.top;
-		return {
-			canvasX: ( clientX - ( this.panX || 0 ) ) / this.zoom,
-			canvasY: ( clientY - ( this.panY || 0 ) ) / this.zoom
-		};
+		throw new Error( 'PointerController not initialized: getRawClientPoint requires PointerController' );
 	}
 
 	addHorizontalGuide ( y ) {


### PR DESCRIPTION
Centralize optional controller initialization in CanvasManager to reduce duplication and make future controller extractions (like PointerController) safer and easier to test.